### PR TITLE
add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: c
+sudo: required
+services:
+    - docker
+os:
+    - osx
+    - linux
+    
+compiler:
+    - clang
+    - gcc
+
+before_install:
+    - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+        sudo apt-get update -qq
+        && sudo apt-get install -qq g++-4.8 libboost-all-dev libevent-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
+        ;
+      fi
+ 
+install:
+    - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+        export CXX="g++-4.8"
+        && export CC="gcc-4.8"
+        ;
+      else
+        brew install hidapi libevent qt5
+        ;
+      fi
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang
+    - libudev-dev
+    - libusb-1.0-0-dev
+    - libevent-dev
+
+matrix:
+    fast_finish:
+        - true
+
+
+before_script:
+    - cd $TRAVIS_BUILD_DIR
+    - git clone git://github.com/signal11/hidapi.git
+    - cd hidapi && ./bootstrap && ./configure --prefix=$TRAVIS_BUILD_DIR && make install && cd ..
+    - git submodule init
+    - git submodule update
+
+script: 
+    - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+        ./autogen.sh
+        && ./configure CXX=g++-4.8 --with-hid-libdir=/home/travis/build/jonasschnelli/dbb-app/lib --with-hid-includedir=/home/travis/build/jonasschnelli/dbb-app/include --enable-daemon --with-gui=qt5 --enable-debug
+        ;
+     else
+        ./autogen.sh
+        && ./configure --enable-daemon --with-gui=qt5 --enable-debug
+        ;
+     fi
+    - make

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](http://img.shields.io/:License-MIT-yellow.svg)](LICENSE)
-
+[![Build Status](https://travis-ci.org/digitalbitbox/dbb-app.svg?branch=master)](https://travis-ci.org/digitalbitbox/dbb-app)
 
 ## DBB-APP
 A QT based application for the [Digital Bitbox](https://digitalbitbox.com) hardware wallet. The application support managing your dbb device (create new wallet, backup, set 2FA key, etc.). It also supports co-signing together with a [Bitpay Copay Wallet](http://copay.io).

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
-AC_PREREQ([2.69])
+AC_PREREQ([2.68])
 AC_INIT([Digital Bitbox CLI],[0.1],[https://github.com/jonasschnelli/dbb_cli/issues],[dbb_cli])
 AC_CONFIG_SRCDIR([src/config])
 AC_CONFIG_HEADERS([src/config/dbb-config.h])


### PR DESCRIPTION
Got it running after 51 tries.
Took me a while to figure out how to support C++11 and Qt5.x.
Solution was to use Docker (for Ubuntu/Linux).

Native OSX builds are also working.

https://travis-ci.org/jonasschnelli/dbb-app/jobs/84048227
