### PR TITLE
Improve "sign" command transmission

### DIFF
--- a/src/libbitpay-wallet-client/bpwalletclient.cpp
+++ b/src/libbitpay-wallet-client/bpwalletclient.cpp
@@ -489,7 +489,7 @@ bool BitPayWalletClient::GetTransactionHistory(std::string& response)
     return true;
 }
 
-void BitPayWalletClient::ParseTxProposal(const UniValue& txProposal, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes)
+void BitPayWalletClient::ParseTxProposal(const UniValue& txProposal, std::string& serTx, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes)
 {
     btc_tx* tx = btc_tx_new();
 
@@ -637,8 +637,8 @@ void BitPayWalletClient::ParseTxProposal(const UniValue& txProposal, std::vector
 
     cstring* txser = cstr_new_sz(1024);
     btc_tx_serialize(txser, tx);
-    std::string txHex = DBB::HexStr((unsigned char*)txser->str, (unsigned char*)txser->str + txser->len);
-    BP_LOG_MSG("\n\nhextx: %s\n\n", txHex.c_str());
+    serTx = DBB::HexStr((unsigned char*)txser->str, (unsigned char*)txser->str + txser->len);
+    BP_LOG_MSG("\n\nhextx: %s\n\n", serTx.c_str());
     int cnt = 0;
 
     for (cnt = 0; cnt < tx->vin->len; cnt++) {

--- a/src/libbitpay-wallet-client/bpwalletclient.cpp
+++ b/src/libbitpay-wallet-client/bpwalletclient.cpp
@@ -489,7 +489,7 @@ bool BitPayWalletClient::GetTransactionHistory(std::string& response)
     return true;
 }
 
-void BitPayWalletClient::ParseTxProposal(const UniValue& txProposal, std::string& serTx, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes)
+void BitPayWalletClient::ParseTxProposal(const UniValue& txProposal, UniValue& changeAddressData, std::string& serTx, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes)
 {
     btc_tx* tx = btc_tx_new();
 
@@ -612,9 +612,9 @@ void BitPayWalletClient::ParseTxProposal(const UniValue& txProposal, std::string
     }
 
     // find out change address
-    UniValue changeAddrObj = find_value(txProposal, "changeAddress");
-    keys = changeAddrObj.getKeys();
-    values = changeAddrObj.getValues();
+    changeAddressData = find_value(txProposal, "changeAddress");
+    keys = changeAddressData.getKeys();
+    values = changeAddressData.getValues();
     std::string changeAdr = "";
     for (i = 0; i < keys.size(); i++) {
         UniValue val = values[i];

--- a/src/libbitpay-wallet-client/bpwalletclient.h
+++ b/src/libbitpay-wallet-client/bpwalletclient.h
@@ -98,7 +98,7 @@ public:
     bool GetTransactionHistory(std::string& response);
 
     //!parse a transaction proposal, export inputs keypath/hashes ready for signing
-    void ParseTxProposal(const UniValue& txProposal, std::string& serTx, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes);
+    void ParseTxProposal(const UniValue& txProposal, UniValue& changeAddressData, std::string& serTx, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes);
 
     //!post signatures for a transaction proposal to the wallet server
     bool PostSignaturesForTxProposal(const UniValue& txProposal, const std::vector<std::string>& vHexSigs);

--- a/src/libbitpay-wallet-client/bpwalletclient.h
+++ b/src/libbitpay-wallet-client/bpwalletclient.h
@@ -98,7 +98,7 @@ public:
     bool GetTransactionHistory(std::string& response);
 
     //!parse a transaction proposal, export inputs keypath/hashes ready for signing
-    void ParseTxProposal(const UniValue& txProposal, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes);
+    void ParseTxProposal(const UniValue& txProposal, std::string& serTx, std::vector<std::pair<std::string, std::vector<unsigned char> > >& vInputTxHashes);
 
     //!post signatures for a transaction proposal to the wallet server
     bool PostSignaturesForTxProposal(const UniValue& txProposal, const std::vector<std::string>& vHexSigs);

--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -1568,7 +1568,8 @@ void DBBDaemonGui::PaymentProposalAction(DBBWallet* wallet, const UniValue& paym
         return;
     }
     std::vector<std::pair<std::string, std::vector<unsigned char> > > inputHashesAndPaths;
-    wallet->client.ParseTxProposal(paymentProposal, inputHashesAndPaths);
+    std::string serTx;
+    wallet->client.ParseTxProposal(paymentProposal, serTx, inputHashesAndPaths);
 
     //build sign command
     std::string hashCmd;
@@ -1583,7 +1584,7 @@ void DBBDaemonGui::PaymentProposalAction(DBBWallet* wallet, const UniValue& paym
     std::string hexHash = DBB::HexStr(&inputHashesAndPaths[0].second[0], &inputHashesAndPaths[0].second[0] + 32);
 
 
-    std::string command = "{\"sign\": { \"type\": \"meta\", \"meta\" : \"somedata\", \"data\" : [ " + hashCmd + " ] } }";
+    std::string command = "{\"sign\": { \"type\": \"meta\", \"meta\" : \""+serTx+"\", \"data\" : [ " + hashCmd + " ] } }";
     printf("Command: %s\n", command.c_str());
 
     bool ret = false;


### PR DESCRIPTION
Command to the DBB will looks something like this:

``` json
{"sign": 
{ "type": "meta",
 "meta" : "0100000001643c5e11fc891a877ce30378898bce75cd7e0636e8e3741c722f4f0251a9e8570000000027002551210292e716490af570e0f43d866491c47125cc122c8226e3ba63a8f2f77bcef7a72751aeffffffff0240420f000000000017a914d62c49aa0dd6229429c6e5ca9d97ed31a97c894c877cb72a000000000017a914b8bb6236ccccd08594ea1a6b183730002bb397b98700000000",
"data" : [ { "hash" : "e817e95b735604c9fbd006eb95b590df9f5f1a8a4ab1f678a0fb483532e042ba", "keypath" : "m/203'/45'/2147483647/0/11" } ],
"checkpub" : [{"pubkey":"02085fcca41f4f81b668eaf1443f3f6f440cdd1d9410702f164d53eaff89238045","keypath":"m/2147483647/1/6"}] } }
```

This currently breaks signing until the DBB can work with "pubkey" instead of "address".
