### PR TITLE
Add QRSequence widget, allow to verify address over a sequence of QRCodes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,7 +59,9 @@ QT_FORMS_UI = \
   qt/ui/paymentproposal.ui \
   qt/ui/backupdialog.ui \
   qt/ui/signconfirmationdialog.ui \
-  qt/ui/getaddressdialog.ui
+  qt/ui/getaddressdialog.ui \
+  qt/ui/verificationdialog.ui \
+  qt/ui/qrcodesequence.ui
 	
 DBB_GUI_H = \
 	qt/paymentproposal.h \
@@ -67,7 +69,9 @@ DBB_GUI_H = \
     qt/dbb_websocketserver.h \
     qt/bonjourserviceregister.h \
     qt/bonjourrecord.h \
-    qt/getaddressdialog.h
+    qt/getaddressdialog.h \
+    qt/qrcodesequence.h \
+    qt/verificationdialog.h
 
 DBB_GUI_CPP = \
 	qt/paymentproposal.cpp \
@@ -75,7 +79,9 @@ DBB_GUI_CPP = \
     qt/signconfirmationdialog.cpp \
     qt/dbb_websocketserver.cpp \
     qt/bonjourserviceregister.cpp \
-    qt/getaddressdialog.cpp
+    qt/getaddressdialog.cpp \
+    qt/qrcodesequence.cpp \
+    qt/verificationdialog.cpp
 
 QT_MOC_CPP = \
 	qt/moc_dbb_gui.cpp \
@@ -84,14 +90,18 @@ QT_MOC_CPP = \
     qt/moc_signconfirmationdialog.cpp \
     qt/moc_dbb_websocketserver.cpp \
     qt/moc_bonjourserviceregister.cpp \
-    qt/moc_getaddressdialog.cpp
+    qt/moc_getaddressdialog.cpp \
+    qt/moc_qrcodesequence.cpp \
+    qt/moc_verificationdialog.cpp
 
 QT_MOC = \
   qt/dbb_gui.moc \
   qt/paymentproposal.moc \
   qt/backupdialog.moc \
   qt/singconfirmationdialog.moc \
-  qt/getaddressdialog.moc
+  qt/getaddressdialog.moc \
+  qt/qrcodesequence.moc \
+  qt/verificationdialog.moc
 
 QT_FORMS_H=$(join $(dir $(QT_FORMS_UI)),$(addprefix ui_, $(notdir $(QT_FORMS_UI:.ui=.h))))
 
@@ -99,7 +109,7 @@ $(QT_MOC): $(QT_FORMS_H)
 $(dbb_app_OBJECTS) $(dbb_app_OBJECTS) : | $(QT_MOC)
 
 dbb_app_SOURCES += qt/dbb_gui.h $(DBB_GUI_H) qt/dbb_gui.cpp qt/qrc_dbbgui.cpp $(QT_MOC_CPP) $(QT_MOC) $(QT_FORMS_UI) $(DBB_GUI_CPP) 
-dbb_app_CPPFLAGS += $(QT_INCLUDES) $(QT_DBUS_INCLUDES)
+dbb_app_CPPFLAGS += $(QT_INCLUDES) $(QT_DBUS_INCLUDES) -I$(srcdir)/qt
 dbb_app_LDFLAGS += $(QT_LDFLAGS)
 dbb_app_LDADD += $(QT_LIBS) $(QT_DBUS_LIBS) $(QR_LIBS) -lcurl $(LINUX_LIBS)
 

--- a/src/qt/dbb_gui.h
+++ b/src/qt/dbb_gui.h
@@ -24,6 +24,7 @@
 #include "getaddressdialog.h"
 #include "paymentproposal.h"
 #include "signconfirmationdialog.h"
+#include "verificationdialog.h"
 
 #define WEBSOCKET_PORT 25698
 
@@ -106,6 +107,7 @@ private:
     Ui::MainWindow* ui;
     BackupDialog* backupDialog;
     GetAddressDialog* getAddressDialog;
+    VerificationDialog* verificationDialog;
     WebsocketServer *websocketServer;
     BonjourServiceRegister *bonjourRegister;
     QStandardItemModel *transactionTableModel;

--- a/src/qt/qrcodesequence.cpp
+++ b/src/qt/qrcodesequence.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2015 Jonas Schnelli / Shift Devices AG
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "qrcodesequence.h"
+#include "ui/ui_qrcodesequence.h"
+
+#include <cmath>
+
+QRCodeSequence::QRCodeSequence(QWidget* parent) : QWidget(parent), ui(new Ui::QRCodeSequence)
+{
+    ui->setupUi(this);
+
+    connect(ui->nextButton, SIGNAL(clicked()), this, SLOT(nextButton()));
+    connect(ui->prevButton, SIGNAL(clicked()), this, SLOT(prevButton()));
+}
+
+QRCodeSequence::~QRCodeSequence()
+{
+    removeQRcodes();
+    delete ui;
+}
+
+void QRCodeSequence::removeQRcodes()
+{
+    for (QRcode *qrcode : qrcodes)
+    {
+        QRcode_free(qrcode);
+    }
+    qrcodes.clear();
+}
+
+void QRCodeSequence::nextButton()
+{
+    if (currentPage < qrcodes.size()-1)
+        showPage(currentPage+1);
+}
+
+void QRCodeSequence::prevButton()
+{
+    if (currentPage > 0)
+        showPage(currentPage-1);
+}
+
+void QRCodeSequence::showPage(int page)
+{
+    if (page >= qrcodes.size())
+        return;
+
+    QRcode *code = qrcodes[page];
+    if (code)
+    {
+        QImage myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
+        myImage.fill(0xffffff);
+        unsigned char *p = code->data;
+        for (int y = 0; y < code->width; y++)
+        {
+            for (int x = 0; x < code->width; x++)
+            {
+                myImage.setPixel(x + 4, y + 4, ((*p & 1) ? 0x0 : 0xffffff));
+                p++;
+            }
+        }
+
+        QIcon qrCode;
+        QPixmap pixMap = QPixmap::fromImage(myImage).scaled(240, 240);
+        qrCode.addPixmap(pixMap, QIcon::Normal);
+        qrCode.addPixmap(pixMap, QIcon::Disabled);
+        ui->qrCode->setIcon(qrCode);
+        ui->qrCode->setIconSize(QSize(ui->qrCode->width(), ui->qrCode->height()));
+    }
+
+    ui->pageLabel->setText(QString::number(page+1)+"/"+QString::number(qrcodes.size()));
+    currentPage = page;
+}
+
+void QRCodeSequence::setData(const std::string& data)
+{
+    removeQRcodes();
+    
+    size_t maxSize = data.size();
+    int numPages = ceil(maxSize/QRCODE_MAX_CHARS);
+
+    // for now, don't allow more then 9 pages
+    if (numPages > 10)
+        return;
+
+    int i;
+    for (i=0;i<numPages;i++)
+    {
+        size_t pageSize = QRCODE_MAX_CHARS;
+        if (i == numPages-1)
+            pageSize = maxSize - (numPages-1) * QRCODE_MAX_CHARS;
+
+        std::string subStr = data.substr(i*QRCODE_MAX_CHARS, pageSize);
+
+        if (numPages > 1)
+            subStr = QRCODE_SEQUENCE_HEADER0 + std::to_string(i) + std::to_string(numPages) + subStr ;
+
+        QRcode *code = QRcode_encodeString(subStr.c_str(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+        qrcodes.push_back(code);
+    }
+
+    showPage(0);
+}

--- a/src/qt/qrcodesequence.h
+++ b/src/qt/qrcodesequence.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2015 Jonas Schnelli
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef QRCODESEQUENCE_H
+#define QRCODESEQUENCE_H
+
+#define QRCODE_MAX_CHARS 200.0
+#define QRCODE_SEQUENCE_HEADER0 "QS"
+
+#include <QWidget>
+
+#include <qrencode.h>
+
+namespace Ui {
+    class QRCodeSequence;
+}
+
+class QRCodeSequence : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit QRCodeSequence(QWidget* parent = 0);
+    ~QRCodeSequence();
+    void setData(const std::string &data);
+
+public slots:
+    void nextButton();
+    void prevButton();
+    void showPage(int page = 0);
+
+private:
+    Ui::QRCodeSequence *ui;
+    std::vector<QRcode *>qrcodes;
+    void removeQRcodes();
+    int currentPage;
+};
+
+#endif // QRCODESEQUENCE_H

--- a/src/qt/ui/qrcodesequence.ui
+++ b/src/qt/ui/qrcodesequence.ui
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QRCodeSequence</class>
+ <widget class="QWidget" name="QRCodeSequence">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>160</width>
+    <height>192</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QPushButton" name="prevButton">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>160</y>
+     <width>60</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Prev</string>
+   </property>
+   <property name="autoDefault">
+    <bool>false</bool>
+   </property>
+   <property name="default">
+    <bool>false</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="nextButton">
+   <property name="geometry">
+    <rect>
+     <x>100</x>
+     <y>160</y>
+     <width>60</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Next</string>
+   </property>
+   <property name="default">
+    <bool>false</bool>
+   </property>
+<property name="autoDefault">
+<bool>false</bool>
+</property>
+  </widget>
+  <widget class="QLabel" name="pageLabel">
+   <property name="geometry">
+    <rect>
+     <x>60</x>
+     <y>160</y>
+     <width>41</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>1/10</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="qrCode">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>160</width>
+     <height>150</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="iconSize">
+    <size>
+     <width>150</width>
+     <height>150</height>
+    </size>
+   </property>
+   <property name="flat">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/ui/verificationdialog.ui
+++ b/src/qt/ui/verificationdialog.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>VerificationDialog</class>
+ <widget class="QDialog" name="VerificationDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>521</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QLabel" name="titleLabel">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>501</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>16</pointsize>
+     <weight>75</weight>
+     <bold>true</bold>
+    </font>
+   </property>
+   <property name="text">
+    <string>Title</string>
+   </property>
+  </widget>
+  <widget class="QRCodeSequence" name="qrCodeSequence" native="true">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>40</y>
+     <width>160</width>
+     <height>190</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="closeButton">
+   <property name="geometry">
+    <rect>
+     <x>400</x>
+     <y>200</y>
+     <width>113</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Close</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="detailTextLabel">
+   <property name="geometry">
+    <rect>
+     <x>175</x>
+     <y>40</y>
+     <width>335</width>
+     <height>150</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QRCodeSequence</class>
+   <extends>QWidget</extends>
+   <header>qrcodesequence.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/verificationdialog.cpp
+++ b/src/qt/verificationdialog.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 Jonas Schnelli / Shift Devices AG
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "verificationdialog.h"
+#include "ui/ui_verificationdialog.h"
+
+VerificationDialog::VerificationDialog(QWidget *parent) :
+QDialog(parent),
+ui(new Ui::VerificationDialog)
+{
+    ui->setupUi(this);
+
+    connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(close()));
+}
+
+
+void VerificationDialog::setData(const QString& title, const QString& detailText, const std::string& qrCodeData)
+{
+    ui->titleLabel->setText(title);
+    ui->detailTextLabel->setText(detailText);
+    ui->qrCodeSequence->setData(qrCodeData);
+}
+
+
+VerificationDialog::~VerificationDialog()
+{
+    delete ui;
+}

--- a/src/qt/verificationdialog.h
+++ b/src/qt/verificationdialog.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 Jonas Schnelli
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DBB_VERIFICATIONDIALOG_H
+#define DBB_VERIFICATIONDIALOG_H
+
+#include <QDialog>
+#include "qrcodesequence.h"
+
+namespace Ui {
+    class VerificationDialog;
+}
+
+class VerificationDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit VerificationDialog(QWidget *parent = 0);
+    ~VerificationDialog();
+    void setData(const QString& title, const QString& detailText, const std::string& qrCodeData);
+
+private:
+    Ui::VerificationDialog *ui;
+};
+
+#endif // DBB_VERIFICATIONDIALOG_H


### PR DESCRIPTION
Currently only implemented for verifying addresses.
IIRC, some of the QRCode readers have problem ready bar bytes (non hex), the current header is in ASCII. First two chars are `QS` (header) followed by two numbers 0-9 (ASCII) which indicates current page (**index**, first number), total num of pages (second number). Max pages is 9 for now.
QRCode size per page is 200+4 characters (=408 bytes).

<img width="810" alt="bildschirmfoto 2015-12-02 um 17 08 00" src="https://cloud.githubusercontent.com/assets/178464/11536104/5059049c-9917-11e5-9895-1bcac644ca97.png">
