### PR TITLE
fixes for compiling for linux from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ Linux (Ubuntu 15.04):
 
 Basics
 
-    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config git
-    sudo apt-get libhidapi-dev
+    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config git libcurl4-openssl-dev libqrencode-dev
+    sudo apt-get install libhidapi-dev
 
 For the daemon
 
-    sudo apt-get libevent-dev
+    sudo apt-get install libevent-dev
 
 For QT UI
 
@@ -145,4 +145,4 @@ Basic build steps:
     ./configure --enable-debug --with-gui=qt5
     make
     sudo make install
-    
+

--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ BITCOIN_QT_CONFIGURE([$use_pkgconfig], [qt5])
 case $host in
   *linux*)
    AC_SEARCH_LIBS(udev_queue_get_queue_is_empty, udev, , AC_MSG_ERROR(udev is required!))
-   AC_CHECK_LIB(hidapi-hidraw, hid_open)
+   AC_CHECK_LIB(hidapi-libusb, hid_open)
    ;;
   *darwin*)
    CXXFLAGS="$CXXFLAGS"
@@ -283,7 +283,7 @@ case $host in
    ;;
 esac
 AC_CHECK_HEADER([hidapi/hidapi.h],,AC_MSG_ERROR(hidapi headers missing))
-AC_SEARCH_LIBS([hid_open], [hidapi hidapi-hidraw hidapi-libusb], , AC_MSG_ERROR(hiapi is required!), [-lhidapi])
+AC_SEARCH_LIBS([hid_open], [hidapi hidapi-libusb], , AC_MSG_ERROR(hiapi is required!), [-lhidapi])
 dnl AC_CHECK_LIB([hidapi], [hid_open], , AC_MSG_ERROR(hiapi is required!))
 
 


### PR DESCRIPTION
1 - Added required dependencies to the README.md: `curl` and `qrencode`. `libcurl-dev` is a 'virtual package' only available from other packages - I arbitrarily choose the openssl version. Ref: http://packages.ubuntu.com/trusty/libcurl-dev

2 - Changed to use the `libusb` version of the `hidapi` library because the `hidraw` version was not working on my setup. `hidapi` has two versions for linux: `libusb` or `hidraw`. `libusb` is default in the library, but the dbb app is using `hidraw` without instructions on how to enable it. `libusb` works without extra instructions required. Ref: https://github.com/signal11/hidapi/tree/master/linux
