### PR TITLE
Detect devices in uninitialized state

### DIFF
--- a/include/dbb.h
+++ b/include/dbb.h
@@ -19,6 +19,7 @@ enum dbb_device_mode {
     DBB_DEVICE_NO_DEVICE = 0,
     DBB_DEVICE_MODE_BOOTLOADER,
     DBB_DEVICE_MODE_FIRMWARE,
+    DBB_DEVICE_MODE_FIRMWARE_NO_PASSWORD,
     DBB_DEVICE_UNKNOWN,
 };
 //!open a connection to the digital bitbox device

--- a/src/libdbb/dbb.cpp
+++ b/src/libdbb/dbb.cpp
@@ -98,6 +98,8 @@ enum dbb_device_mode deviceAvailable()
         if ((vSNParts.size() == 2 && vSNParts[0] == "dbb.fw") || strSN == "firmware")
         {
             foundType = DBB_DEVICE_MODE_FIRMWARE;
+            if (vSNParts[1].size() > 2 && vSNParts[1][vSNParts[1].size()-2] == '-' && vSNParts[1][vSNParts[1].size()-1] == '-')
+                foundType = DBB_DEVICE_MODE_FIRMWARE_NO_PASSWORD;
             break;
         }
         else if (vSNParts.size() == 2 && vSNParts[0] == "dbb.bl")

--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -394,7 +394,7 @@ void DBBDaemonGui::changeConnectedState(bool state, int deviceType)
     }
 
     if (stateChanged) {
-        if (state && deviceType == DBB::DBB_DEVICE_MODE_FIRMWARE) {
+        if (state && (deviceType == DBB::DBB_DEVICE_MODE_FIRMWARE || deviceType == DBB::DBB_DEVICE_MODE_FIRMWARE_NO_PASSWORD)) {
             deviceConnected = true;
             //: translation: device connected status bar
             DBB::LogPrint("Device connected\n", "");
@@ -500,6 +500,11 @@ void DBBDaemonGui::uiUpdateDeviceState(int deviceType)
         {
             hideModalInfo();
             askForSessionPassword();
+        }
+        else if (deviceType == DBB::DBB_DEVICE_MODE_FIRMWARE_NO_PASSWORD)
+        {
+            hideModalInfo();
+            showSetPasswordInfo(true);
         }
     }
 }

--- a/src/qt/modalview.cpp
+++ b/src/qt/modalview.cpp
@@ -92,6 +92,7 @@ void ModalView::showSetPasswordInfo(bool showCleanInfo)
 
     ui->setPassword->setEnabled(false);
     showOrHide(true);
+    ui->setPassword->setEnabled(false);
 }
 
 void ModalView::showModalInfo(const QString &info, int helpType)


### PR DESCRIPTION
Allow to detect devices in uninitialized mode (no password set).
