### PR TITLE
Make betaicon not interfere with clicks

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -147,6 +147,7 @@ DBBDaemonGui::DBBDaemonGui(QWidget* parent) : QMainWindow(parent),
     this->ui->mainSettingsButton->setStyleSheet(buttonCss);
     this->ui->multisigButton->setStyleSheet(msButtonCss);
 
+    this->ui->betaIcon->setAttribute(Qt::WA_TransparentForMouseEvents);
 
     this->ui->balanceLabel->setStyleSheet("font-size: " + QString::fromStdString(balanceFontSize) + ";");
     this->ui->singleWalletBalance->setStyleSheet("font-size: " + QString::fromStdString(balanceFontSize) + ";");
@@ -321,7 +322,6 @@ DBBDaemonGui::DBBDaemonGui(QWidget* parent) : QMainWindow(parent),
 
     connect(this->ui->overviewButton, SIGNAL(clicked()), this, SLOT(mainOverviewButtonClicked()));
     connect(this->ui->multisigButton, SIGNAL(clicked()), this, SLOT(mainMultisigButtonClicked()));
-    connect(this->ui->betaIcon, SIGNAL(clicked()), this, SLOT(mainOverviewButtonClicked()));
     connect(this->ui->receiveButton, SIGNAL(clicked()), this, SLOT(mainReceiveButtonClicked()));
     connect(this->ui->sendButton, SIGNAL(clicked()), this, SLOT(mainSendButtonClicked()));
     connect(this->ui->mainSettingsButton, SIGNAL(clicked()), this, SLOT(mainSettingsButtonClicked()));

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -1598,7 +1598,7 @@ background-color: rgba(0,0,0, 0%)</string>
      <bool>true</bool>
     </property>
    </widget>
-   <widget class="QPushButton" name="betaIcon">
+   <widget class="QLabel" name="betaIcon">
     <property name="enabled">
      <bool>true</bool>
     </property>
@@ -1626,19 +1626,17 @@ background-color: rgba(0,0,0, 0%)</string>
      <string notr="true">QPushButton:pressed { background-color: transparent; }
 </string>
     </property>
-    <property name="icon">
-     <iconset>
-      <normaloff>:/icons/betabadge</normaloff>
-      <disabledoff>:/icons/betabadge</disabledoff>:/icons/betabadge</iconset>
+    <property name="text">
+     <string notr="true"/>
     </property>
-    <property name="iconSize">
-     <size>
-      <width>53</width>
-      <height>53</height>
-     </size>
+    <property name="pixmap">
+     <pixmap resource="../dbbgui.qrc">:/icons/betabadge</pixmap>
     </property>
-    <property name="flat">
+    <property name="scaledContents">
      <bool>true</bool>
+    </property>
+    <property name="textInteractionFlags">
+     <set>Qt::NoTextInteraction</set>
     </property>
    </widget>
    <zorder>titlebar</zorder>


### PR DESCRIPTION
Having the beta icon act as button feels weird. I think this is more what one'd expect.
- Change `betaIcon` to a QLabel
- Make mouse events 'pass through' with Qt::WA_TransparentForMouseEvents
