### PR TITLE
LED commands for updated dbb API

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -708,7 +708,7 @@ void DBBDaemonGui::proceedVerification(const QString& twoFACode, void *ptr, cons
         //cancle pressed
         ui->modalBlockerView->clearTXData();
         hideModalInfo();
-        ledClicked();
+        ledClicked(DBB_LED_BLINK_MODE_ABORT);
         if (comServer)
             comServer->postNotification("{ \"action\" : \"clear\" }");
         return;
@@ -920,12 +920,18 @@ void DBBDaemonGui::eraseClicked()
     }
 }
 
-void DBBDaemonGui::ledClicked()
+void DBBDaemonGui::ledClicked(dbb_led_blink_mode_t mode)
 {
-    executeCommandWrapper("{\"led\" : \"toggle\"}", DBB_PROCESS_INFOLAYER_STYLE_NO_INFO, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
+    std::string command;
+    if (mode == DBB_LED_BLINK_MODE_BLINK)
+        command = "{\"led\" : \"blink\"}";
+    else if (mode == DBB_LED_BLINK_MODE_ABORT)
+        command = "{\"led\" : \"abort\"}";
+    else 
+        return;
+    executeCommandWrapper(command, DBB_PROCESS_INFOLAYER_STYLE_NO_INFO, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
         UniValue jsonOut;
         jsonOut.read(cmdOut);
-
         emit gotResponse(jsonOut, status, DBB_RESPONSE_TYPE_LED_BLINK);
     });
 }

--- a/src/qt/dbb_gui.h
+++ b/src/qt/dbb_gui.h
@@ -90,6 +90,11 @@ typedef enum DBB_PROCESS_INFOLAYER_STYLE {
     DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON_WARNING
 } dbb_process_infolayer_style_t;
 
+typedef enum DBB_LED_BLINK_MODE {
+    DBB_LED_BLINK_MODE_BLINK,
+    DBB_LED_BLINK_MODE_ABORT
+} dbb_led_blink_mode_t;
+
 class DBBDaemonGui : public QMainWindow
 {
     Q_OBJECT
@@ -281,7 +286,7 @@ private slots:
     //== DBB USB ==
     //!function is user whishes to erase the DBB
     void eraseClicked();
-    void ledClicked();
+    void ledClicked(dbb_led_blink_mode_t mode = DBB_LED_BLINK_MODE_BLINK);
     //!get basic informations about the connected DBB
     void getInfo();
     //!seed the wallet, flush everything and create a new bip32 entropy


### PR DESCRIPTION
Required changes to LED command syntax, matching: 
https://github.com/digitalbitbox/mcu/pull/153
https://github.com/digitalbitbox/mcu/pull/152

Summary of MCU changes:
`toggle` renamed to `blink`
return `success`
add `abort` led blink pattern

Motivation:
During 2FA when the user hits cancel, the LED blink pattern should be the same as the `abort` blink pattern that occurs for a 'short touch'. The normal `blink` pattern should be reserved for accept/ok states. 

`blink` is a more accurate description than `toggle`.
