### PR TITLE
fix runaway polling when no internet connection

### DIFF
--- a/src/dbb_comserver.cpp
+++ b/src/dbb_comserver.cpp
@@ -213,7 +213,7 @@ void DBBComServer::startLongPollThread()
         while(1)
         {
             response = "";
-            httpStatusCode = 0;
+            httpStatusCode = 400;
             {
                 // we store the channel ID to detect channelID changes during long poll 
                 std::unique_lock<std::mutex> lock(cs_com);


### PR DESCRIPTION
`httpStatusCode` should be set at something >= 300. Otherwise, constant polling occurs if there is no internet connection. Doesn't really matter what particular number is used, but `400 Bad Request` seemed to be logical, where 4XX codes indicate client errors. 
