### PR TITLE
small touch up to history table look

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -2190,13 +2190,12 @@ void DBBDaemonGui::updateTransactionTable(DBBWallet *wallet, bool historyAvailab
     if (!historyAvailable || !history.isArray())
         return;
 
-    transactionTableModel = new  QStandardItemModel(history.size(), 5, this);
+    transactionTableModel = new  QStandardItemModel(history.size(), 4, this);
 
     transactionTableModel->setHeaderData(0, Qt::Horizontal, QObject::tr("TXID"));
     transactionTableModel->setHeaderData(1, Qt::Horizontal, QObject::tr("Amount"));
     transactionTableModel->setHeaderData(2, Qt::Horizontal, QObject::tr("Address"));
     transactionTableModel->setHeaderData(3, Qt::Horizontal, QObject::tr("Date"));
-    transactionTableModel->setHeaderData(4, Qt::Horizontal, QObject::tr(""));
 
     int cnt = 0;
     for (const UniValue &obj : history.getValues())
@@ -2229,17 +2228,8 @@ void DBBDaemonGui::updateTransactionTable(DBBWallet *wallet, bool historyAvailab
         }
         
         UniValue timeUV = find_value(obj, "time");
-        if (timeUV.isNum())
-        {
-            QDateTime timestamp;
-            timestamp.setTime_t(timeUV.get_int64());
-            QStandardItem *item = new QStandardItem(timestamp.toString(Qt::SystemLocaleShortDate));
-            item->setToolTip(tr("Double-click for more details"));
-            item->setFont(font);
-            transactionTableModel->setItem(cnt, 3, item);
-        }
-            
         UniValue confirmsUV = find_value(obj, "confirmations");
+        if (timeUV.isNum())
         {
             QString iconName;
             QString tooltip;
@@ -2254,10 +2244,14 @@ void DBBDaemonGui::updateTransactionTable(DBBWallet *wallet, bool historyAvailab
                 tooltip = "0";
                 iconName = ":/icons/confirm0";
             }
-            QStandardItem *item = new QStandardItem(QIcon(iconName), "");
+            
+            QDateTime timestamp;
+            timestamp.setTime_t(timeUV.get_int64());
+            QStandardItem *item = new QStandardItem(QIcon(iconName), timestamp.toString(Qt::SystemLocaleShortDate));
             item->setToolTip(tooltip + tr(" confirmations"));
             item->setTextAlignment(Qt::AlignCenter); 
-            transactionTableModel->setItem(cnt, 4, item);
+            item->setFont(font);
+            transactionTableModel->setItem(cnt, 3, item);
         }
 
         UniValue txidUV = find_value(obj, "txid");
@@ -2274,13 +2268,12 @@ void DBBDaemonGui::updateTransactionTable(DBBWallet *wallet, bool historyAvailab
     ui->tableWidget->setColumnHidden(0, true);
 
     if (cnt) {
-        ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-        ui->tableWidget->setColumnHidden(4, false);
-        ui->tableWidget->setColumnWidth(4, 0); // Trick to get column smaller than minimum width
-                                               // when resized in setSectionResizeMode().
+        ui->tableWidget->horizontalHeader()->setStretchLastSection(false);
+        ui->tableWidget->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+        ui->tableWidget->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+        ui->tableWidget->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
     } else {
         ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-        ui->tableWidget->setColumnHidden(4, true);
     }
 }
 


### PR DESCRIPTION
with this commit (number of confirmations shows up as a tooltip in the date column):

![screen shot 2016-06-12 at 12 50 36](https://cloud.githubusercontent.com/assets/7711591/15990747/9951960a-309d-11e6-9ff3-eb0eeaa7c079.png)

before:
![screen shot 2016-06-12 at 12 50 14](https://cloud.githubusercontent.com/assets/7711591/15990749/a9ded7da-309d-11e6-98ed-f44367a02be3.png)
