### PR TITLE
overhaul multisig tab (part 2)

### DIFF
--- a/src/bitpaywalletclient/bpwalletclient.cpp
+++ b/src/bitpaywalletclient/bpwalletclient.cpp
@@ -56,7 +56,7 @@ std::string BitPayWalletClient::ReversePairs(std::string const& src)
     return result;
 }
 
-BitPayWalletClient::BitPayWalletClient(std::string dataDirIn, bool testnetIn) : dataDir(dataDirIn), testnet(testnetIn)
+BitPayWalletClient::BitPayWalletClient(std::string dataDirIn, bool testnetIn) : dataDir(dataDirIn), testnet(testnetIn), walletJoined(false)
 {
     //set the default wallet service
     ca_file = "";
@@ -1105,6 +1105,8 @@ void BitPayWalletClient::SaveLocalData()
         uint32_t lastKnownAddressLength = lastKnownAddressJson.size();
         fwrite(&lastKnownAddressLength, 1, sizeof(lastKnownAddressLength), writeFile);
         fwrite(&lastKnownAddressJson.front(), 1, lastKnownAddressLength, writeFile);
+        
+        fwrite(&walletJoined, 1, sizeof(walletJoined), writeFile);
     }
     fclose(writeFile);
 }
@@ -1146,6 +1148,9 @@ void BitPayWalletClient::LoadLocalData()
                 return;
         } else
             lastKnownAddressJson = "";
+        
+        if (fread(&walletJoined, 1, sizeof(walletJoined), fh) != sizeof(walletJoined))
+            return;
 
         fclose(fh);
     }
@@ -1166,6 +1171,7 @@ void BitPayWalletClient::setNull()
     masterPubKey.clear();
     masterPubKey.clear();
     memset(requestKey.privkey,0, 32);
+    walletJoined = false;
 }
 
 int BitPayWalletClient::CheapRandom()

--- a/src/bitpaywalletclient/bpwalletclient.h
+++ b/src/bitpaywalletclient/bpwalletclient.h
@@ -155,6 +155,9 @@ public:
 
     //!returns true in case of an available xpub/request key
     bool IsSeeded();
+    
+    //!whether or not a Copay wallet was joined with the xpub/request key
+    bool walletJoined;
 
     //!local filename (absolute)
     const std::string localDataFilename(const std::string& dataDir);

--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -550,7 +550,7 @@ void DBBDaemonGui::resetInfos()
 
     updateOverviewFlags(false, false, true);
 
-    //reset wallet
+    //reset single wallet UI
     ui->tableWidget->setModel(NULL);
     ui->balanceLabel->setText("");
     ui->singleWalletBalance->setText("");
@@ -558,6 +558,13 @@ void DBBDaemonGui::resetInfos()
     ui->qrCode->setToolTip("");
     ui->keypathLabel->setText("");
     ui->currentAddress->setText("");
+    
+    //reset multisig wallet UI
+    ui->multisigWalletName->setText("");
+    ui->multisigBalance->setText(" -- ");
+    ui->joinCopayWallet->setEnabled(true);
+    ui->proposalsLabel->setText(tr("Current Payment Proposals")); 
+    hidePaymentProposalsWidget(); 
 }
 
 void DBBDaemonGui::uiUpdateDeviceState(int deviceType)
@@ -1507,7 +1514,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
 
                 updateOverviewFlags(cachedWalletAvailableState, cachedDeviceLock, false);
 
-                bool shouldCreateSingleWallet = false;
+                bool shouldCreateWallet = false;
                 if (cachedWalletAvailableState && walletIDUV.isStr())
                 {
                     //initializes wallets (filename, get address, etc.)
@@ -1521,7 +1528,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                         updateReceivingAddress(singleWallet, lastAddress, keypath);
 
                         if (singleWallet->client.GetXPubKey().size() <= 0)
-                            shouldCreateSingleWallet = true;
+                            shouldCreateWallet = true;
                     }
                     if (vMultisigWallets[0]->client.getFilenameBase().empty())
                     {
@@ -1529,7 +1536,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                         vMultisigWallets[0]->client.LoadLocalData();
                     }
                 }
-                if (shouldCreateSingleWallet)
+                if (shouldCreateWallet)
                 {
                     //: translation: modal info during copay wallet creation
                     showModalInfo(tr("Creating Wallet"));
@@ -1804,12 +1811,12 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                     errorString = QString::fromStdString(errorObj.get_str());
             }
             if (!seedObj.isNull() && seedObj.isStr() && seedObj.get_str() == "success") {
-                //remove local wallets
+                // clear wallet information
                 if (singleWallet)
-                    singleWallet->client.RemoveLocalData();
+                    singleWallet->client.setNull();
 
                 if (vMultisigWallets[0])
-                    vMultisigWallets[0]->client.RemoveLocalData();
+                    vMultisigWallets[0]->client.setNull();
 
                 resetInfos();
                 getInfo();
@@ -1821,8 +1828,8 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                 sessionPasswordDuringChangeProcess.clear();
 
                 //remove local wallets
-                singleWallet->client.RemoveLocalData();
-                vMultisigWallets[0]->client.RemoveLocalData();
+                singleWallet->client.setNull();
+                vMultisigWallets[0]->client.setNull();
 
                 resetInfos();
                 getInfo();

--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -1549,8 +1549,8 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                 {
                     if (sdcard.isBool() && !sdcard.isTrue())
                     {
-                        //: translation: warning text if SDCard needs to be insert for wallet creation
-                        showModalInfo(tr("Please insert a SDCard and replug the device. Initializing the wallet is only possible with a SDCard (otherwise you don't have a backup!)."));
+                        //: translation: warning text if micro SD card needs to be inserted for wallet creation
+                        showModalInfo(tr("Please insert a micro SD card and replug the device. Initializing the wallet is only possible with an SD card. Otherwise, you will not have a backup."));
                         updateModalWithIconName(":/icons/touchhelp_sdcard_in");
                         return;
                     }
@@ -1565,8 +1565,8 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
 
                 if (sdcard.isBool() && sdcard.isTrue() && cachedWalletAvailableState && !sdcardWarned)
                 {
-                    //: translation: warning text if SDCard is insert in productive environment
-                    showModalInfo(tr("Keep the SD card safe unless doing backups or restores"), DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON);
+                    //: translation: warning text if micro SD card is inserted
+                    showModalInfo(tr("Keep the SD card somewhere safe unless doing backups or restores."), DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON);
                     updateModalWithIconName(":/icons/touchhelp_sdcard");
 
                     sdcardWarned = true;
@@ -1692,9 +1692,6 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                     sentToVerificationClients = true;
                     comServer->postNotification(responseMutable.write());
                 }
-
-
-
             }
             if (!sentToVerificationClients)
             {

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -471,7 +471,7 @@ background-color: rgba(240,240,240,255);
         </layout>
        </item>
        <item>
-        <widget class="Line" name="line_2">
+        <widget class="Line" name="multisigLine">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>


### PR DESCRIPTION
- Do not delete wallet.dat files. Instead clear local memory containing the wallet information. In this way, a multisig wallet can be reloaded, avoiding UX bugs when rejoining an existing multisig wallet. Now, when reloading a wallet with multisig data, the tab will automatically display the same information as seen before.
- Hide non-applicable multisig UI elements, depending on the wallet state. (see below)
- Contains an add-on commit to update some UI text messages.

![screen shot 2016-06-18 at 13 00 21](https://cloud.githubusercontent.com/assets/7711591/16170723/0a8195be-355d-11e6-8dbb-07a6004b6ffb.png)
![screen shot 2016-06-18 at 13 47 00](https://cloud.githubusercontent.com/assets/7711591/16170724/13744d6a-355d-11e6-8f8f-31487c3551bd.png)
![screen shot 2016-06-18 at 13 16 29](https://cloud.githubusercontent.com/assets/7711591/16170725/1859141e-355d-11e6-8b31-6f03c76cedcf.png)
