### PR TITLE
update device name before creating a new wallet

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -194,7 +194,7 @@ DBBDaemonGui::DBBDaemonGui(const QString& uri, QWidget* parent) : QMainWindow(pa
     connect(ui->eraseButton, SIGNAL(clicked()), this, SLOT(eraseClicked()));
     connect(ui->ledButton, SIGNAL(clicked()), this, SLOT(ledClicked()));
     connect(ui->passwordButton, SIGNAL(clicked()), this, SLOT(showSetPasswordInfo()));
-    connect(ui->seedButton, SIGNAL(clicked()), this, SLOT(seedHardware()));
+    connect(ui->seedButton, SIGNAL(clicked()), this, SLOT(seedHardwareWithName()));
     connect(ui->refreshButton, SIGNAL(clicked()), this, SLOT(SingleWalletUpdateWallets()));
     connect(ui->getNewAddress, SIGNAL(clicked()), this, SLOT(getNewAddress()));
     connect(ui->verifyAddressButton, SIGNAL(clicked()), this, SLOT(verifyAddress()));
@@ -373,7 +373,9 @@ DBBDaemonGui::DBBDaemonGui(const QString& uri, QWidget* parent) : QMainWindow(pa
     connect(this->ui->passwordLineEdit, SIGNAL(returnPressed()), this, SLOT(passwordProvided()));
 
     //set password screen
-    connect(this->ui->modalBlockerView, SIGNAL(newPasswordAvailable(const QString&, const QString&, bool)), this, SLOT(setPasswordProvided(const QString&, const QString&, bool)));
+    connect(this->ui->modalBlockerView, SIGNAL(newPasswordAvailable(const QString&, const QString&)), this, SLOT(setPasswordProvided(const QString&, const QString&)));
+    connect(this->ui->modalBlockerView, SIGNAL(newDeviceNamePasswordAvailable(const QString&, const QString&)), this, SLOT(setDeviceNamePasswordProvided(const QString&, const QString&)));
+    connect(this->ui->modalBlockerView, SIGNAL(newDeviceNameAvailable(const QString&)), this, SLOT(setDeviceNameProvided(const QString&)));
     connect(this->ui->modalBlockerView, SIGNAL(signingShouldProceed(const QString&, void *, const UniValue&, int)), this, SLOT(proceedVerification(const QString&, void *, const UniValue&, int)));
     //modal general signals
     connect(this->ui->modalBlockerView, SIGNAL(modalViewWillShowHide(bool)), this, SLOT(modalStateChanged(bool)));
@@ -599,7 +601,7 @@ void DBBDaemonGui::uiUpdateDeviceState(int deviceType)
         else if (deviceType == DBB::DBB_DEVICE_MODE_FIRMWARE_NO_PASSWORD)
         {
             hideModalInfo();
-            showSetPasswordInfo(true);
+            this->ui->modalBlockerView->showSetNewWallet();
         }
     }
 }
@@ -830,30 +832,39 @@ void DBBDaemonGui::hideSessionPasswordView()
     animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
-void DBBDaemonGui::showSetPasswordInfo(bool newWallet)
+void DBBDaemonGui::showSetPasswordInfo()
 {
-    ui->modalBlockerView->showSetPasswordInfo(newWallet);
+    ui->modalBlockerView->showSetPassword();
 }
 
-void DBBDaemonGui::setPasswordProvided(const QString& newPassword, const QString& extraInput, bool newWallet)
+void DBBDaemonGui::setPasswordProvided(const QString& newPassword, const QString& repeatPassword)
 {
-    dbb_process_infolayer_style_t process; 
     std::string command = "{\"password\" : \"" + newPassword.toStdString() + "\"}";
     
-    if (newWallet) {
-        tempNewDeviceName = extraInput;
-        process = DBB_PROCESS_INFOLAYER_STYLE_NO_INFO;
-    } else {
-        if (extraInput.toStdString() != sessionPassword) {
-            showModalInfo(tr("Incorrect old password"), DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON);
-            return;
-        }
-        process = DBB_PROCESS_INFOLAYER_STYLE_TOUCHBUTTON;
+    if (repeatPassword.toStdString() != sessionPassword) {
+        showModalInfo(tr("Incorrect old password"), DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON);
+        return;
     }
 
     showModalInfo(tr("Saving Password"));
+    if (executeCommandWrapper(command, DBB_PROCESS_INFOLAYER_STYLE_TOUCHBUTTON, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
+        UniValue jsonOut;
+        jsonOut.read(cmdOut);
+        emit gotResponse(jsonOut, status, DBB_RESPONSE_TYPE_PASSWORD);
+    }))
+    {
+        sessionPasswordDuringChangeProcess = sessionPassword;
+        sessionPassword = newPassword.toStdString();
+    }
+}
 
-    if (executeCommandWrapper(command, process, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
+void DBBDaemonGui::setDeviceNamePasswordProvided(const QString& newPassword, const QString& newName)
+{
+    tempNewDeviceName = newName;
+    
+    std::string command = "{\"password\" : \"" + newPassword.toStdString() + "\"}";
+    showModalInfo(tr("Saving Password"));
+    if (executeCommandWrapper(command, DBB_PROCESS_INFOLAYER_STYLE_NO_INFO, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
         UniValue jsonOut;
         jsonOut.read(cmdOut);
         emit gotResponse(jsonOut, status, DBB_RESPONSE_TYPE_PASSWORD);
@@ -988,6 +999,11 @@ std::string DBBDaemonGui::getBackupString()
     std::stringstream ss;
     ss << name << "-" << DBB::putTime(in_time_t, "%Y-%m-%d-%H-%M-%S");
     return ss.str();
+}
+
+void DBBDaemonGui::seedHardwareWithName()
+{
+    ui->modalBlockerView->showSetDeviceNameCreate();
 }
 
 void DBBDaemonGui::seedHardware()
@@ -1211,6 +1227,11 @@ void DBBDaemonGui::upgradeFirmwareDone(bool status)
     }
 
 
+}
+
+void DBBDaemonGui::setDeviceNameProvided(const QString &name)
+{
+    setDeviceName(name, DBB_RESPONSE_TYPE_SET_DEVICE_NAME_RECREATE);
 }
 
 void DBBDaemonGui::setDeviceNameClicked()
@@ -1466,7 +1487,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                 errorShown = true;
             } else if (errorCodeObj.isNum() && errorCodeObj.get_int() == 101) {
                 sessionPassword.clear();
-                showSetPasswordInfo(true);
+                this->ui->modalBlockerView->showSetNewWallet();
             } else {
                 //password wrong
                 showAlert(tr("Error"), QString::fromStdString(errorMessageObj.get_str()));
@@ -1763,13 +1784,15 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
         else if (tag == DBB_RESPONSE_TYPE_BOOTLOADER_LOCK) {
             hideModalInfo();
         }
-        else if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME || tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE) {
+        else if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME || tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE || tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_RECREATE) {
             UniValue name = find_value(response, "name");
             if (name.isStr()) {
                 deviceName = QString::fromStdString(name.get_str());
                 this->ui->deviceNameLabel->setText("<strong>Name:</strong> "+deviceName);
                 if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE)
                     getInfo();
+                if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_RECREATE)
+                    seedHardware();
             }
         }
         else {
@@ -1901,7 +1924,7 @@ void DBBDaemonGui::getNewAddress()
             }
             else
             {
-                emit shouldShowAlert("Error", tr("Could not set a new Receiving address.\n\nNote that internet access is required in order to track the address on the blockchain and update your balance.\n\nFor advanced use, untracked addresses can be generated offline with the List Addresses button in the Settings tab."));
+                emit shouldShowAlert("Error", tr("Could not get a new receiving address."));
             }
 
             thread->completed();

--- a/src/qt/dbb_gui.h
+++ b/src/qt/dbb_gui.h
@@ -77,6 +77,7 @@ typedef enum DBB_RESPONSE_TYPE {
     DBB_RESPONSE_TYPE_BOOTLOADER_LOCK,
     DBB_RESPONSE_TYPE_SET_DEVICE_NAME,
     DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE,
+    DBB_RESPONSE_TYPE_SET_DEVICE_NAME_RECREATE,
 } dbb_response_type_t;
 
 typedef enum DBB_ADDRESS_STYLE {
@@ -282,9 +283,11 @@ private slots:
     void hideModalInfo();
     void modalStateChanged(bool state);
     //!show set passworf form
-    void showSetPasswordInfo(bool newWallet = false);
+    void showSetPasswordInfo();
     //!gets called when the user presses button in the "set password form"
-    void setPasswordProvided(const QString& newPassword, const QString& extraInput, bool newWallet = false);
+    void setPasswordProvided(const QString& newPassword, const QString& repeatPassword);
+    //!gets called on device reset
+    void setDeviceNamePasswordProvided(const QString& newPassword, const QString& newName);
     void cleanseLoginAndSetPassword();
 
     //== DBB USB ==
@@ -295,6 +298,8 @@ private slots:
     void getInfo();
     //!seed the wallet, flush everything and create a new bip32 entropy
     void seedHardware();
+    //!update device name before continuing to seed the wallet
+    void seedHardwareWithName();
 
     //== DBB USB / UTILS ==
     //!get the current local IPv4 address
@@ -310,7 +315,9 @@ private slots:
     //!start upgrading the firmware with a file at given location
     void upgradeFirmwareWithFile(const QString& fileName);
     void upgradeFirmwareDone(bool state);
-    //!change device name
+    //!change device name via modal display
+    void setDeviceNameProvided(const QString &name);
+    //!change device name via popup window
     void setDeviceNameClicked();
     void setDeviceName(const QString& newDeviceName, dbb_response_type_t response_type);
     void parseBitcoinURI(const QString& bitcoinurl, QString& addressOut, QString& amountOut);

--- a/src/qt/modalview.h
+++ b/src/qt/modalview.h
@@ -22,18 +22,23 @@ public:
     Ui::ModalView *ui;
 
 signals:
-    void newPasswordAvailable(const QString&, const QString&, bool);
+    void newPasswordAvailable(const QString&, const QString&);
+    void newDeviceNamePasswordAvailable(const QString&, const QString&);
+    void newDeviceNameAvailable(const QString&);
     void signingShouldProceed(const QString&, void *, const UniValue&, int);
     void modalViewWillShowHide(bool);
 
 public slots:
     void showOrHide(bool state = false);
-    void showSetPasswordInfo(bool newWallet = false);
+    void showSetNewWallet();
+    void showSetPassword();
+    void showSetDeviceNameCreate();
     void showModalInfo(const QString &info, int helpType);
     void showTransactionVerification(bool twoFAlocked, bool showQRSqeuence = false);
-    void setPasswordProvided();
-    void cancelSetPasswordProvided();
+    void deviceSubmitProvided();
+    void deviceCancelProvided();
     void cleanse();
+    void setDeviceHideAll();
     void setText(const QString& text);
     void updateIcon(const QIcon& icon);
 
@@ -44,9 +49,9 @@ public slots:
     void detailButtonAction();
     void okButtonAction();
     void proceedFrom2FAToSigning(const QString &twoFACode);
-    void twoFACanclePressed();
+    void twoFACancelPressed();
 
-    void passwordCheck(const QString& password0);
+    void inputCheck(const QString& sham);
     void continuePressed();
 
 protected:

--- a/src/qt/ui/modalview.ui
+++ b/src/qt/ui/modalview.ui
@@ -77,7 +77,7 @@
     <bool>true</bool>
    </property>
   </widget>
-  <widget class="QWidget" name="setPasswordWidget" native="true">
+  <widget class="QWidget" name="setDeviceWidget" native="true">
    <property name="geometry">
     <rect>
      <x>40</x>
@@ -110,6 +110,33 @@
        <property name="styleSheet">
            <string notr="true">color: white;
                background-color: rgba(0,0,0, 0%)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="setDeviceNameOnly">
+       <property name="font">
+        <font>
+         <pointsize>20</pointsize>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background:white;
+                              border:0px;
+                              border-radius: 5px;
+                              padding:4px;</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="maxLength">
+        <number>64</number>
+       </property>
+       <property name="echoMode">
+        <enum>QLineEdit::Normal</enum>
+       </property>
+       <property name="placeholderText">
+        <string>Wallet name</string>
        </property>
       </widget>
      </item>
@@ -181,7 +208,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLineEdit" name="setPassword0">
+      <widget class="QLineEdit" name="setPasswordNew">
        <property name="font">
         <font>
          <pointsize>20</pointsize>
@@ -205,7 +232,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="setPassword1">
+      <widget class="QLineEdit" name="setPasswordRepeat">
        <property name="font">
         <font>
          <pointsize>20</pointsize>
@@ -237,7 +264,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QPushButton" name="setPassword">
+        <widget class="QPushButton" name="setDeviceSubmit">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
            <horstretch>0</horstretch>
@@ -266,7 +293,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="cancelSetPassword">
+        <widget class="QPushButton" name="setDeviceCancel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
            <horstretch>0</horstretch>
@@ -296,7 +323,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="passwordWarning">
+        <widget class="QLabel" name="setDeviceWarning">
          <property name="styleSheet">
           <string notr="true">color: orange;</string>
          </property>
@@ -311,7 +338,7 @@
       </layout>
      </item>
      <item>
-      <widget class="QLabel" name="passwordInfo2">
+      <widget class="QLabel" name="setDevicePasswordInfo">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -455,7 +482,7 @@
   </widget>
   <zorder>modalBgWidget</zorder>
   <zorder>modalIcon</zorder>
-  <zorder>setPasswordWidget</zorder>
+  <zorder>setDeviceWidget</zorder>
   <zorder>qrCodeSequence</zorder>
   <zorder>modalInfoLabelLA</zorder>
   <zorder>modalInfoLabel</zorder>


### PR DESCRIPTION
Motivation: A backup is automatically saved when creating a new wallet. If a new name is not set, the backup will have the same name as the previous wallet, which can lead to confusion when recovering from a backup, or accidental erasing the wrong backup.

Note that `modalview.cpp` was getting complicated, so I made an attempt to refactor naming and function calls in order to be easier to understand.
