### PR TITLE
minor options tab changes

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -1530,7 +1530,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                     this->ui->deviceNameLabel->setText("<strong>Name:</strong> "+deviceName);
                 }
 
-                this->ui->DBBAppVersion->setText("DBB v"+QString(DBB_PACKAGE_VERSION) + "-" + VERSION);
+                this->ui->DBBAppVersion->setText("v"+QString(DBB_PACKAGE_VERSION));
 
                 updateOverviewFlags(cachedWalletAvailableState, cachedDeviceLock, false);
 

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -769,10 +769,10 @@ background-color: rgba(240,240,240,255);
             </size>
            </property>
            <property name="toolTip">
-            <string>Check online if there are updates for your Digital Bitbox.</string>
+            <string>Check online for software updates.</string>
            </property>
            <property name="text">
-            <string>Check For Updates...</string>
+            <string>Check for Updates...</string>
            </property>
           </widget>
          </item>
@@ -811,7 +811,7 @@ background-color: rgba(240,240,240,255);
             </size>
            </property>
            <property name="toolTip">
-            <string>Securely upgrade your DigitalBitbox firmware</string>
+            <string>Securely upgrade your Digital Bitbox firmware.</string>
            </property>
            <property name="text">
             <string>Upgrade Firmware...</string>
@@ -853,7 +853,7 @@ background-color: rgba(240,240,240,255);
             </size>
            </property>
            <property name="toolTip">
-            <string>Expert configuration options for DBB-APP</string>
+            <string>Expert configuration settings.</string>
            </property>
            <property name="text">
             <string>Settings...</string>

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -880,13 +880,13 @@ background-color: rgba(240,240,240,255);
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout3">
            <property name="leftMargin">
-            <number>6</number>
+            <number>25</number>
            </property>
            <property name="topMargin">
             <number>0</number>
            </property>
            <property name="rightMargin">
-            <number>6</number>
+            <number>25</number>
            </property>
            <property name="bottomMargin">
             <number>5</number>


### PR DESCRIPTION
Update toottip text for consistency, accuracy, grammar.
For the release, don't display the git hash and reduce redundant or superfluous text for the app version name.
Adjust version name locations slightly to better align with buttons.
![screen shot 2016-07-22 at 23 12 03](https://cloud.githubusercontent.com/assets/7711591/17071559/8ac32092-5062-11e6-809b-1cc63690c28b.png)
