### PR TITLE
make update check compatible with update server

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -432,6 +432,7 @@ DBBDaemonGui::DBBDaemonGui(const QString& uri, QWidget* parent) : QMainWindow(pa
 #endif
 
     connect(ui->checkForUpdates, SIGNAL(clicked()), updateManager, SLOT(checkForUpdate()));
+    connect(updateManager, SIGNAL(updateButtonSetAvailable(bool)), this, SLOT(updateButtonSetAvailable(bool)));
     QTimer::singleShot(200, updateManager, SLOT(checkForUpdateInBackground()));
 }
 
@@ -907,6 +908,18 @@ void DBBDaemonGui::updateModalWithIconName(const QString& filename)
 void DBBDaemonGui::updateOverviewFlags(bool walletAvailable, bool lockAvailable, bool loading)
 {
 
+}
+
+void DBBDaemonGui::updateButtonSetAvailable(bool available)
+{
+    if (available) {
+        this->ui->checkForUpdates->setText(tr("Update Available"));
+        this->ui->checkForUpdates->setStyleSheet("font-weight: bold");
+    }
+    else {
+        this->ui->checkForUpdates->setText(tr("Check for Updates..."));
+        this->ui->checkForUpdates->setStyleSheet("font-weight: normal");
+    }
 }
 
 /*

--- a/src/qt/dbb_gui.h
+++ b/src/qt/dbb_gui.h
@@ -287,6 +287,8 @@ private slots:
     //!gets called on device reset
     void setDeviceNamePasswordProvided(const QString& newPassword, const QString& newName);
     void cleanseLoginAndSetPassword();
+    //!gets called when checking for an update
+    void updateButtonSetAvailable(bool);
 
     //== DBB USB ==
     //!function is user whishes to erase the DBB

--- a/src/qt/update.h
+++ b/src/qt/update.h
@@ -16,6 +16,7 @@ class DBBUpdateManager : public QWidget
 signals:
     //emitted when check-for-updates response is available
     void checkForUpdateResponseAvailable(const std::string&, long, bool);
+    void updateButtonSetAvailable(bool);
 
 public:
     DBBUpdateManager();


### PR DESCRIPTION
In addition, for the update check on startup, emphasize that an update is available in the Options tab instead of always showing a popup, which could get annoying after a while.

![screen shot 2016-07-24 at 10 40 32](https://cloud.githubusercontent.com/assets/7711591/17082824/67f43d88-518b-11e6-91c6-6ea7c50dbc5a.png)
