### PR TITLE
update no 2FA popup text

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -703,7 +703,7 @@ void DBBDaemonGui::showEchoVerification(DBBWallet* wallet, const UniValue& propo
         else
         {
             //no verification device connected, start QRCode based verification
-            QMessageBox::warning(this, tr(""), tr("No mobile app detected. Manually verify the transaction by scanning the sequence of QR codes with a paired Digital Bitbox mobile app."), QMessageBox::Ok);
+            QMessageBox::warning(this, tr(""), tr("No mobile app detected.<br><br>Optionally, you can verify the transaction by manually scanning the sequence of QR codes with a paired Digital Bitbox mobile app."), QMessageBox::Ok);
         }
 
     }
@@ -1719,7 +1719,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                     verificationDialog = new VerificationDialog();
 
                 verificationDialog->show();
-                verificationDialog->setData(tr("Securely Verify Your Receiving Address"), tr("No mobile app detected. Manually verify the address by scanning QR codes with a paired Digital Bitbox mobile app."), responseMutable.write());
+                verificationDialog->setData(tr("Securely Verify Your Receiving Address"), tr("No mobile app detected.<br><br>You can verify the address by manually scanning QR codes with a paired Digital Bitbox mobile app."), responseMutable.write());
             }
         } else if (tag == DBB_RESPONSE_TYPE_LIST_BACKUP && backupDialog) {
             UniValue backupObj = find_value(response, "backup");


### PR DESCRIPTION
To avoid user confusion, be clear that the manual qr code scanning when no 2fa device is detected is optional.
