### PR TITLE
Fix bug causing some modal displays to not show

### DIFF
--- a/src/qt/modalview.cpp
+++ b/src/qt/modalview.cpp
@@ -325,7 +325,7 @@ void ModalView::proceedFrom2FAToSigning(const QString &twoFACode)
 
 void ModalView::twoFACancelPressed()
 {
-    ui->qrCodeSequence->setVisible(false);
+    setQrCodeVisibility(false);
     ui->abortButton->setVisible(false);
 
     if (txPointer)


### PR DESCRIPTION
Occurs when hitting the 'Cancel' button during a signing process when a mobile phone is not connected.