### PR TITLE
Remove unused line reading JSON pubkey value from sign cmd

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -2772,7 +2772,6 @@ void DBBDaemonGui::PaymentProposalAction(DBBWallet* wallet, const QString &tfaCo
                         int sigCount = 0;
                         for (const UniValue& oneSig : vSignatureObjects) {
                             UniValue sigObject = find_value(oneSig, "sig");
-                            UniValue pubKey = find_value(oneSig, "pubkey");
                             if (sigObject.isNull() || !sigObject.isStr()) {
                                 wallet->mapHashSig.clear();
                                 DBB::LogPrint("Invalid signature from device\n", "");


### PR DESCRIPTION
This is a required change because the Digital Bitbox API will no longer return `pubkey`, instead returning `recid` (recoverable ID -> can recover the pubkey from the signature + recid).