### PR TITLE
Add send-max option

### DIFF
--- a/src/bitpaywalletclient/bpwalletclient.cpp
+++ b/src/bitpaywalletclient/bpwalletclient.cpp
@@ -567,7 +567,7 @@ bool BitPayWalletClient::GetFeeLevels()
         return false;
 
     long httpStatusCode = 0;
-    if (!SendRequest("get", "/v1/feelevels/?network=livenet&r="+std::to_string(CheapRandom()), "{}", response, httpStatusCode))
+    if (!SendRequest("get", "/v1/feelevels/?network="+std::string(testnet ? "testnet" : "livenet")+"&r="+std::to_string(CheapRandom()), "{}", response, httpStatusCode))
         return false;
 
     if (httpStatusCode != 200)

--- a/src/bitpaywalletclient/bpwalletclient.h
+++ b/src/bitpaywalletclient/bpwalletclient.h
@@ -99,7 +99,9 @@ public:
     //!Return the last (disk) cached known address for receiving coins
     bool GetLastKnownAddress(std::string& address, std::string& keypath);
 
-    bool CreatePaymentProposal(const std::string& address, uint64_t amount, uint64_t feeperkb, UniValue& paymentProposalOut, std::string& errorOut);
+    //!Creates a payment proposal
+    //! If amount is set to 0, it tired to create a proposal with all available funds
+    bool CreatePaymentProposal(const std::string& address, uint64_t amount, uint64_t feeperkb, UniValue& paymentProposalOut, std::string& errorOut, bool checkSingleOutput = false);
 
     bool PublishTxProposal(const UniValue& paymentProposal, std::string& errorOut);
 

--- a/src/qt/dbb_gui.h
+++ b/src/qt/dbb_gui.h
@@ -359,6 +359,7 @@ private slots:
     //!gets called when a new address is available
     void updateReceivingAddress(DBBWallet *wallet, const std::string &newAddress, const std::string &keypath);
     //!check the UI values and create a payment proposal from them, sign and post them
+    void sendMaxCheckboxDidChange(int val);
     void createTxProposalPressed();
     //!Report about a submitted payment proposal
     void reportPaymentProposalPost(DBBWallet* wallet, const UniValue& proposal);

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -1270,6 +1270,27 @@ background-color: rgba(240,240,240,255);
          </item>
         </layout>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
+         <property name="topMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="feeInfo">
+           <property name="text">
+            <string>Fee</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="sendMax">
+           <property name="text">
+            <string>Send all available funds</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
     </widget>


### PR DESCRIPTION
Adds a client side send max feature.
This is relatively hacky and may fail quickly depending on BWS server side fixes/updates.
See also: https://github.com/bitpay/bitcore-wallet-service/issues/660

Not sure if we already want to merge this.