### PR TITLE
various minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ addons:
     - g++-4.8
     - clang
     - libudev-dev
-    - libusb-dev
     - libusb-1.0-0-dev
     - libevent-dev
 
@@ -50,7 +49,7 @@ script:
     - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
         QTDIR="/opt/qt55" && PATH="$QTDIR/bin:$PATH" && qt55-env.sh
         && ./autogen.sh
-        && PKG_CONFIG_PATH="/opt/qt55/lib/pkgconfig:$PKG_CONFIG_PATH" ./configure CXX=g++-4.8 --enable-daemon --with-gui=qt5 --enable-debug
+        && PKG_CONFIG_PATH="/opt/qt55/lib/pkgconfig:$PKG_CONFIG_PATH" ./configure CXX=g++-4.8 --enable-daemon --with-gui=qt5 --enable-debug --enable-libusb
         ;
      else
         ./autogen.sh

--- a/src/bitpaywalletclient/bpwalletclient.cpp
+++ b/src/bitpaywalletclient/bpwalletclient.cpp
@@ -631,7 +631,7 @@ bool BitPayWalletClient::GetTransactionHistory(std::string& response)
         return false;
 
     long httpStatusCode = 0;
-    if (!SendRequest("get", "/v1/txhistory/?limit=50&r="+std::to_string(CheapRandom()), "{}", response, httpStatusCode))
+    if (!SendRequest("get", "/v1/txhistory/?r="+std::to_string(CheapRandom()), "{}", response, httpStatusCode))
         return false;
 
     if (httpStatusCode != 200)

--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -1668,13 +1668,19 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                             DBB::LogPrint("Upgrading firmware\n", "");
                             firmwareFileToUse = "int";
                             DBB::LogPrint("Request bootloader unlock\n", "");
-                            executeCommandWrapper("{\"bootloader\" : \"unlock\" }", DBB_PROCESS_INFOLAYER_STYLE_TOUCHBUTTON, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
+                            bool unlockSuccess = false;
+                            executeCommandWrapper("{\"bootloader\" : \"unlock\" }", DBB_PROCESS_INFOLAYER_STYLE_TOUCHBUTTON, [this, &unlockSuccess](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
                                 UniValue jsonOut;
                                 jsonOut.read(cmdOut);
                                 emit gotResponse(jsonOut, status, DBB_RESPONSE_TYPE_BOOTLOADER_UNLOCK);
+                                if (upgradeFirmwareState) {
+                                    unlockSuccess = true;
+                                }
                             }, tr("Unlock the bootloader to install a new firmware"));
-                            passwordAccepted();
-                            return;
+                            if (unlockSuccess) {
+                                passwordAccepted();
+                                return;
+                            }
                         }
                     }
                 } catch (std::exception &e) {

--- a/src/qt/modalview.cpp
+++ b/src/qt/modalview.cpp
@@ -144,6 +144,7 @@ void ModalView::showSetNewWallet()
     ui->setDevicePasswordInfo->setVisible(true);
     ui->setDeviceName->setFocus();
     ui->setDeviceSubmit->setEnabled(false);
+    ui->setDeviceCancel->setVisible(false);
 }
 
 void ModalView::showSetPassword()
@@ -158,6 +159,7 @@ void ModalView::showSetPassword()
     ui->setDevicePasswordInfo->setVisible(true);
     ui->setPasswordOld->setFocus();
     ui->setDeviceSubmit->setEnabled(false);
+    ui->setDeviceCancel->setVisible(true);
 }
 
 void ModalView::showSetDeviceNameCreate()

--- a/src/qt/ui/modalview.ui
+++ b/src/qt/ui/modalview.ui
@@ -181,7 +181,7 @@
                               padding:4px;</string>
        </property>
        <property name="maxLength">
-        <number>64</number>
+        <number>1048</number>
        </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
@@ -221,7 +221,7 @@
                               padding:4px;</string>
        </property>
        <property name="maxLength">
-        <number>64</number>
+        <number>1048</number>
        </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
@@ -245,7 +245,7 @@
                               padding:4px;</string>
        </property>
        <property name="maxLength">
-        <number>64</number>
+        <number>1048</number>
        </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>


### PR DESCRIPTION
* Always load complete history
* Remove cancel button during device initialisation
* Extend 64-chars password limit to 1048
* Better update-behavior during wallet loading
* Don't end up in a non-useable state when abort firmware upgrade during init
* Enable libusb-1.0 in travis