### PR TITLE
Fix Connection Error in netLoaded atomic

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -2624,6 +2624,8 @@ void DBBDaemonGui::parseWalletsResponse(DBBWallet* wallet, bool walletsAvailable
     else
         multisigWalletIsUpdating = false;
 
+    netLoaded = false;
+
     UniValue response;
     if (response.read(walletsResponse) && response.isObject()) {
         DBB::LogPrint("Got update wallet response...\n", "");


### PR DESCRIPTION
The "No response or timeout" error is not shown in the wallet, if the internet connection is lost during runtime. 
This seems to be because the netLoaded atomic is not set to false by default. 