### PR TITLE
Add qrencode to OSX instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Libbtc is included as git subtree and will be compiled during the normal build p
 
 OSX:
 
-    brew install hidapi libevent qt5
+    brew install hidapi libevent qt5 qrencode
 
 #### Linux (Ubuntu 15.04):
 


### PR DESCRIPTION
OSX apparently requires qrencode now.
